### PR TITLE
ObjMethod: Always pass context.Context for API method calls

### DIFF
--- a/type.go
+++ b/type.go
@@ -282,11 +282,6 @@ func newMethod(m reflect.Method, receiverKind reflect.Kind) *ObjMethod {
 	}
 	t := m.Type
 	switch t.NumIn() - receiverArgCount {
-	case 0:
-		// Method() ...
-		assemble = func(_ context.Context, arg reflect.Value) []reflect.Value {
-			return nil
-		}
 	case 2:
 		// Method(context.Context, T) ...
 		contextParam := t.In(receiverArgCount)
@@ -298,16 +293,11 @@ func newMethod(m reflect.Method, receiverKind reflect.Kind) *ObjMethod {
 			return []reflect.Value{reflect.ValueOf(ctx), arg}
 		}
 	case 1:
-		// Method([context.Context,]T) ...
+		// Method(context.Context) ...
 		param := t.In(receiverArgCount)
 		if contextType.AssignableTo(param) {
 			assemble = func(ctx context.Context, _ reflect.Value) []reflect.Value {
 				return []reflect.Value{reflect.ValueOf(ctx)}
-			}
-		} else {
-			p.Params = param
-			assemble = func(_ context.Context, arg reflect.Value) []reflect.Value {
-				return []reflect.Value{arg}
 			}
 		}
 	default:


### PR DESCRIPTION
All API server calls make passing context.Context optional. This means that most if not all API requests do not utilise the context available to them. This means that it makes it a lot hard to know when a request should be cancelled or discarded.

This will become really useful when migrating a way from mongo and to another database store. Additionally we can start to hang more things from the context allow them to pass through the stack.

This is a breaking change, by forcing context.Context to become non-optional and forcing juju to handle context correctly.